### PR TITLE
Drastically reduce the time for each iteration of running tests from >60s to ~4s (x17!)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,10 @@
 import getCurrentLocationWithTimeout from "index"
 import { TiredFromWaitingPromiseResolveTooLongError } from "promise-until-tired"
 
+beforeAll(() => {
+    jest.useFakeTimers()
+})
+
 describe('getCurrentLocationWithTimeout()', () => {
     const MOCK_RESPONSE = {
         coords: {
@@ -8,11 +12,9 @@ describe('getCurrentLocationWithTimeout()', () => {
             longitude: 45.3
         }
     }
-
     const MOCK_REJECT_RESPONSE = new Error('reject')
-
     const mockGetCurrentPosition = jest.fn()
-    
+
     beforeAll(() => {
         Object.defineProperty(window, 'navigator', {
             value: {
@@ -25,6 +27,7 @@ describe('getCurrentLocationWithTimeout()', () => {
 
     afterEach(() => {
         mockGetCurrentPosition.mockClear()
+        jest.clearAllTimers()
     })
 
     describe('geolocation resolve after timeout', () => {
@@ -33,6 +36,7 @@ describe('getCurrentLocationWithTimeout()', () => {
                 setTimeout(() => {
                     resolve(MOCK_RESPONSE)
                 }, 50000)
+                jest.runAllTimers()
             })
         })
 
@@ -51,6 +55,7 @@ describe('getCurrentLocationWithTimeout()', () => {
                 setTimeout(() => {
                     reject(MOCK_REJECT_RESPONSE)
                 }, 50000)
+                jest.runAllTimers()
             })
         })
 
@@ -69,6 +74,7 @@ describe('getCurrentLocationWithTimeout()', () => {
                 setTimeout(() => {
                     resolve(MOCK_RESPONSE)
                 }, 500)
+                jest.runAllTimers()
             })
         })
 
@@ -87,6 +93,7 @@ describe('getCurrentLocationWithTimeout()', () => {
                 setTimeout(() => {
                     reject(MOCK_REJECT_RESPONSE)
                 }, 500)
+                jest.runAllTimers()
             })
         })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,6 @@
 import getCurrentLocationWithTimeout from "index"
 import { TiredFromWaitingPromiseResolveTooLongError } from "promise-until-tired"
 
-beforeAll(() => {
-    jest.useFakeTimers()
-})
-
 describe('getCurrentLocationWithTimeout()', () => {
     const MOCK_RESPONSE = {
         coords: {
@@ -16,6 +12,7 @@ describe('getCurrentLocationWithTimeout()', () => {
     const mockGetCurrentPosition = jest.fn()
 
     beforeAll(() => {
+        jest.useFakeTimers()
         Object.defineProperty(window, 'navigator', {
             value: {
                 geolocation: {


### PR DESCRIPTION
I just read the test cases and found this code might help to reduce the time for each iteration of testing by using timers by just  [`jest.useFakeTimers()`](https://jestjs.io/docs/timer-mocks) instead of using the actual.

The benefit of this approach is to reduce the testing time from ~>60 seconds to 4 seconds (almost 17x) for running the test cases, test coverage, and ci.

Before:
```md
...
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------|---------|----------|---------|---------|-------------------
All files     |     100 |      100 |     100 |     100 |
 index.ts     |     100 |      100 |     100 |     100 |
 variables.ts |     100 |      100 |     100 |     100 |
--------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        67.299 s
Ran all test suites.
``` 

After:
```md
...
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------|---------|----------|---------|---------|-------------------
All files     |     100 |      100 |     100 |     100 |
 index.ts     |     100 |      100 |     100 |     100 |
 variables.ts |     100 |      100 |     100 |     100 |
--------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        3.998 s
Ran all test suites.
```

Further improvements: just note if anyone wants to improve the test case by spying on the `setTimeout` and validating its calls of type and variables.
